### PR TITLE
Rewrite lambdas to use dependent call syntax

### DIFF
--- a/src/kvasir/mpl/algorithm/all.hpp
+++ b/src/kvasir/mpl/algorithm/all.hpp
@@ -28,7 +28,7 @@ namespace kvasir {
 					};
 				};
 				template <template <typename...> class F>
-				struct not_<lambda<F>> {
+				struct not_<cfe<F,identity>> {
 					template <typename T>
 					struct f {
 						constexpr static bool value = (!F<T>::value);
@@ -43,6 +43,6 @@ namespace kvasir {
 		/// resolves to std::true_type if all elements in the input list
 		/// fulfill the provided predicate
 		template <typename List, template <typename...> class Cond = identity>
-		using all = c::call<c::all<lambda<Cond>>, List>;
+		using all = c::call<c::all<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/any.hpp
+++ b/src/kvasir/mpl/algorithm/any.hpp
@@ -24,6 +24,6 @@ namespace kvasir {
 		/// filter elements from a list
 		/// takes a lambda that should return a type convertible to bool
 		template <typename List, template <typename...> class Cond = identity>
-		using any = c::call<c::any<lambda<Cond>>, List>;
+		using any = c::call<c::any<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/count_if.hpp
+++ b/src/kvasir/mpl/algorithm/count_if.hpp
@@ -20,7 +20,7 @@ namespace kvasir {
 					                                                                    list<>>;
 				};
 				template <template <typename...> class F>
-				struct list_wrap_void_if<lambda<F>> {
+				struct list_wrap_void_if<cfe<F, identity>> {
 					template <typename T>
 					using f = typename conditional<F<T>::value>::template f<list<void>, list<>>;
 				};
@@ -32,6 +32,6 @@ namespace kvasir {
 		/// filter elements from a list
 		/// takes a lambda that should return a type convertible to bool
 		template <typename List, template <typename...> class Cond = identity>
-		using count_if = c::call<c::count_if<lambda<Cond>>, List>;
+		using count_if = c::call<c::count_if<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/count_if.hpp
+++ b/src/kvasir/mpl/algorithm/count_if.hpp
@@ -25,8 +25,8 @@ namespace kvasir {
 					using f = typename conditional<F<T>::value>::template f<list<void>, list<>>;
 				};
 			}
-			template <typename Cond>
-			using count_if = transform<detail::list_wrap_void_if<Cond>, join<size>>;
+			template <typename F = identity>
+			using count_if = transform<detail::list_wrap_void_if<F>, join<size>>;
 		}
 
 		/// filter elements from a list

--- a/src/kvasir/mpl/algorithm/filter.hpp
+++ b/src/kvasir/mpl/algorithm/filter.hpp
@@ -18,6 +18,6 @@ namespace kvasir {
 		/// filter elements from a list
 		/// takes a lambda that should return a type convertible to bool
 		template <typename List, template <typename...> class Cond = identity>
-		using filter = c::call<c::filter<lambda<Cond>>, List>;
+		using filter = c::call<c::filter<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/find_if.hpp
+++ b/src/kvasir/mpl/algorithm/find_if.hpp
@@ -249,16 +249,10 @@ namespace kvasir {
 				using f = typename detail::find_if_impl<detail::first_find(sizeof...(Ts)),
 				                                        C>::template f<F::template f, Ts...>;
 			};
-			template <template <typename...> class F, typename C>
-			struct find_if<lambda<F>, C> {
-				template <typename... Ts>
-				using f = typename detail::find_if_impl<detail::first_find(sizeof...(Ts)),
-				                                        C>::template f<F, Ts...>;
-			};
 		}
 
 		/// fold left over a list, initialized with State
 		template <typename List, template <typename...> class Cond = identity>
-		using find_if = c::call<c::find_if<lambda<Cond>>, List>;
+		using find_if = c::call<c::find_if<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/flatten.hpp
+++ b/src/kvasir/mpl/algorithm/flatten.hpp
@@ -21,11 +21,11 @@ namespace kvasir {
 						Ts))>::template f<list, typename flatten_element_impl<L, Ts>::type...>;
 				};
 			}
-			template<typename SequenceType = lambda<list>, typename C = listify>
+			template<typename SequenceType = cfe<list>, typename C = listify>
 			struct flatten;
 			
 			template<template<typename...> class S, typename C>
-			struct flatten<lambda<S>, C> {
+			struct flatten<cfe<S,identity>, C> {
 				template<typename...Ts>
 				using f = typename detail::join_select<detail::select_join_size(sizeof...(Ts))>::template f<C::template f,
 					typename detail::flatten_element_impl<S, Ts>::type...>;
@@ -37,7 +37,7 @@ namespace kvasir {
 			struct flatten_impl;
 			template<template<typename...> class S, typename...Ts>
 			struct flatten_impl<S<Ts...>> {
-				using type = typename c::flatten<lambda<S>>::template f<Ts...>;
+				using type = typename c::flatten<c::cfe<S>>::template f<Ts...>;
 			};
 		}
 

--- a/src/kvasir/mpl/algorithm/fold_left.hpp
+++ b/src/kvasir/mpl/algorithm/fold_left.hpp
@@ -159,7 +159,7 @@ namespace kvasir {
 				        sizeof...(Ts)-1)>::template f<F::template f, Ts...>;
 			};
 			template <template <typename...> class F>
-			struct fold_left<lambda<F>> {
+			struct fold_left<cfe<F,identity>> {
 				template <typename... Ts>
 				using f = typename detail::fold_impl<detail::select_fold(
 				        sizeof...(Ts)-1)>::template f<F, Ts...>;
@@ -168,6 +168,6 @@ namespace kvasir {
 
 		/// fold left over a list, initialized with State
 		template <typename List, typename State, template <typename...> class Func>
-		using fold_left = c::call<c::fold_left<lambda<Func>>, List, State>;
+		using fold_left = c::call<c::fold_left<c::cfe<Func>>, List, State>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/fold_right.hpp
+++ b/src/kvasir/mpl/algorithm/fold_right.hpp
@@ -175,7 +175,7 @@ namespace kvasir {
 				        sizeof...(Ts)-1)>::template f<F::template f, Ts...>>;
 			};
 			template <template <typename...> class F, typename C>
-			struct fold_right<lambda<F>,C> {
+			struct fold_right<cfe<F,identity>,C> {
 				template <typename... Ts>
 				using f = typename C::template f<typename detail::fold_right_impl<detail::select_fold_right(
 				        sizeof...(Ts)-1)>::template f<F, Ts...>>;
@@ -184,6 +184,6 @@ namespace kvasir {
 
 		/// fold right over a list, initialized with State
 		template <typename List, typename State, template <typename...> class Func>
-		using fold_right = c::call<c::fold_right<lambda<Func>>, List, State>;
+		using fold_right = c::call<c::fold_right<c::cfe<Func>>, List, State>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/fold_right.hpp
+++ b/src/kvasir/mpl/algorithm/fold_right.hpp
@@ -168,17 +168,17 @@ namespace kvasir {
 					        T0>;
 				};
 			}
-			template <typename F>
+			template <typename F, typename C = identity>
 			struct fold_right {
 				template <typename... Ts>
-				using f = typename detail::fold_right_impl<detail::select_fold_right(
-				        sizeof...(Ts)-1)>::template f<F::template f, Ts...>;
+				using f = typename C::template f<typename detail::fold_right_impl<detail::select_fold_right(
+				        sizeof...(Ts)-1)>::template f<F::template f, Ts...>>;
 			};
-			template <template <typename...> class F>
-			struct fold_right<lambda<F>> {
+			template <template <typename...> class F, typename C>
+			struct fold_right<lambda<F>,C> {
 				template <typename... Ts>
-				using f = typename detail::fold_right_impl<detail::select_fold_right(
-				        sizeof...(Ts)-1)>::template f<F, Ts...>;
+				using f = typename C::template f<typename detail::fold_right_impl<detail::select_fold_right(
+				        sizeof...(Ts)-1)>::template f<F, Ts...>>;
 			};
 		}
 

--- a/src/kvasir/mpl/algorithm/lookup.hpp
+++ b/src/kvasir/mpl/algorithm/lookup.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "../types/list.hpp"
+#include "../functional/call.hpp"
 
 namespace kvasir {
 	namespace mpl {

--- a/src/kvasir/mpl/algorithm/lookup.hpp
+++ b/src/kvasir/mpl/algorithm/lookup.hpp
@@ -1,0 +1,244 @@
+//          Copyright Odin Holmes 2016.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.md or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#pragma once
+
+#include "../types/list.hpp"
+
+namespace kvasir {
+	namespace mpl {
+		namespace c {
+			namespace detail {
+
+				template<unsigned>
+				struct index;
+				template<>
+				struct index<0> {
+					template<typename T0, typename...Ts>
+					using f = T0;
+				};
+				template<>
+				struct index<1> {
+					template<typename T0, typename T1, typename...Ts>
+					using f = T1;
+				};
+				template<>
+				struct index<2> {
+					template<typename T0, typename T1, typename T2, typename...Ts>
+					using f = T2;
+				};
+				template<>
+				struct index<3> {
+					template<typename T0, typename T1, typename T2, typename T3, typename...Ts>
+					using f = T3;
+				};
+				template<>
+				struct index<4> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename...Ts>
+					using f = T4;
+				};
+				template<>
+				struct index<5> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename...Ts>
+					using f = T5;
+				};
+				template<>
+				struct index<6> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename...Ts>
+						using f = T6;
+				};
+				template<>
+				struct index<7> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename...Ts>
+						using f = T7;
+				};
+				template<>
+				struct index<8> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename...Ts>
+						using f = T8;
+				};
+				template<>
+				struct index<9> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename...Ts>
+						using f = T9;
+				};
+				template<>
+				struct index<10> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename T10, typename...Ts>
+						using f = T10;
+				};
+				template<>
+				struct index<11> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename T10, typename T11, typename...Ts>
+						using f = T11;
+				};
+				template<>
+				struct index<12> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename...Ts>
+						using f = T12;
+				};
+				template<>
+				struct index<13> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13, typename...Ts>
+						using f = T13;
+				};
+				template<>
+				struct index<14> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13,
+						typename T14, typename...Ts>
+						using f = T14;
+				};
+				template<>
+				struct index<15> {
+					template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+						typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13,
+						typename T14, typename T15, typename...Ts>
+						using f = T15;
+				};
+
+
+				template<typename...Ts>
+				struct indexed {
+					template<template<typename...> class F>
+					using f = F<Ts...>;
+				};
+				template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+					typename T7, typename T8, typename T9, typename T10, typename T11, typename T12, typename T13,
+					typename T14, typename T15, typename Tail>
+					struct indexed<rlist<T0,
+					rlist<T1,
+					rlist<T2,
+					rlist<T3,
+					rlist<T4,
+					rlist<T5,
+					rlist<T6,
+					rlist<T7,
+					rlist<T8,
+					rlist<T9,
+					rlist<T10,
+					rlist<T11,
+					rlist<T12,
+					rlist<T13,
+					rlist<T14,
+					rlist<T15,
+					Tail>>>>>>>>>>>>>>>>> {
+					template<template<typename...> class F>
+					using f = F< T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>;
+				};
+
+				template<unsigned>
+				struct indexed_builder;
+				template<>
+				struct indexed_builder<0> {
+					template<typename Out>
+					using f = Out;
+				};
+				template <>
+				struct indexed_builder<3> {
+					template <typename Out, typename T0 = void, typename T1 = void,
+						typename T2 = void, typename T3 = void, typename T4 = void, typename T5 = void,
+						typename T6 = void, typename T7 = void, typename T8 = void, typename T9 = void,
+						typename T10 = void, typename T11 = void, typename T12 = void, typename T13 = void,
+						typename T14 = void, typename T15 = void, typename T16 = void, typename T17 = void,
+						typename T18 = void, typename T19 = void, typename T20 = void, typename T21 = void,
+						typename T22 = void, typename T23 = void, typename T24 = void, typename T25 = void,
+						typename T26 = void, typename T27 = void, typename T28 = void, typename T29 = void,
+						typename T30 = void, typename T31 = void, typename T32 = void, typename T33 = void,
+						typename T34 = void, typename T35 = void, typename T36 = void, typename T37 = void,
+						typename T38 = void, typename T39 = void, typename T40 = void, typename T41 = void,
+						typename T42 = void, typename T43 = void, typename T44 = void, typename T45 = void,
+						typename T46 = void, typename T47 = void, typename T48 = void, typename T49 = void,
+						typename T50 = void, typename T51 = void, typename T52 = void, typename T53 = void,
+						typename T54 = void, typename T55 = void, typename T56 = void, typename T57 = void,
+						typename T58 = void, typename T59 = void, typename T60 = void, typename T61 = void,
+						typename T62 = void, typename T63 = void, typename T64 = void, typename T65 = void,
+						typename T66 = void, typename T67 = void, typename T68 = void, typename T69 = void,
+						typename T70 = void, typename T71 = void, typename T72 = void, typename T73 = void,
+						typename T74 = void, typename T75 = void, typename T76 = void, typename T77 = void,
+						typename T78 = void, typename T79 = void, typename T80 = void, typename T81 = void,
+						typename T82 = void, typename T83 = void, typename T84 = void, typename T85 = void,
+						typename T86 = void, typename T87 = void, typename T88 = void, typename T89 = void,
+						typename T90 = void, typename T91 = void, typename T92 = void, typename T93 = void,
+						typename T94 = void, typename T95 = void, typename T96 = void, typename T97 = void,
+						typename T98 = void, typename T99 = void, typename T100 = void, typename T101 = void,
+						typename T102 = void, typename T103 = void, typename T104 = void, typename T105 = void,
+						typename T106 = void, typename T107 = void, typename T108 = void, typename T109 = void,
+						typename T110 = void, typename T111 = void, typename T112 = void, typename T113 = void,
+						typename T114 = void, typename T115 = void, typename T116 = void, typename T117 = void,
+						typename T118 = void, typename T119 = void, typename T120 = void, typename T121 = void,
+						typename T122 = void, typename T123 = void, typename T124 = void, typename T125 = void,
+						typename T126 = void, typename T127 = void, typename T128 = void, typename T129 = void,
+						typename T130 = void, typename T131 = void, typename T132 = void, typename T133 = void,
+						typename T134 = void, typename T135 = void, typename T136 = void, typename T137 = void,
+						typename T138 = void, typename T139 = void, typename T140 = void, typename T141 = void,
+						typename T142 = void, typename T143 = void, typename T144 = void, typename T145 = void,
+						typename T146 = void, typename T147 = void, typename T148 = void, typename T149 = void,
+						typename T150 = void, typename T151 = void, typename T152 = void, typename T153 = void,
+						typename T154 = void, typename T155 = void, typename T156 = void, typename T157 = void,
+						typename T158 = void, typename T159 = void, typename T160 = void, typename T161 = void,
+						typename T162 = void, typename T163 = void, typename T164 = void, typename T165 = void,
+						typename T166 = void, typename T167 = void, typename T168 = void, typename T169 = void,
+						typename T170 = void, typename T171 = void, typename T172 = void, typename T173 = void,
+						typename T174 = void, typename T175 = void, typename T176 = void, typename T177 = void,
+						typename T178 = void, typename T179 = void, typename T180 = void, typename T181 = void,
+						typename T182 = void, typename T183 = void, typename T184 = void, typename T185 = void,
+						typename T186 = void, typename T187 = void, typename T188 = void, typename T189 = void,
+						typename T190 = void, typename T191 = void, typename T192 = void, typename T193 = void,
+						typename T194 = void, typename T195 = void, typename T196 = void, typename T197 = void,
+						typename T198 = void, typename T199 = void, typename T200 = void, typename T201 = void,
+						typename T202 = void, typename T203 = void, typename T204 = void, typename T205 = void,
+						typename T206 = void, typename T207 = void, typename T208 = void, typename T209 = void,
+						typename T210 = void, typename T211 = void, typename T212 = void, typename T213 = void,
+						typename T214 = void, typename T215 = void, typename T216 = void, typename T217 = void,
+						typename T218 = void, typename T219 = void, typename T220 = void, typename T221 = void,
+						typename T222 = void, typename T223 = void, typename T224 = void, typename T225 = void,
+						typename T226 = void, typename T227 = void, typename T228 = void, typename T229 = void,
+						typename T230 = void, typename T231 = void, typename T232 = void, typename T233 = void,
+						typename T234 = void, typename T235 = void, typename T236 = void, typename T237 = void,
+						typename T238 = void, typename T239 = void, typename T240 = void, typename T241 = void,
+						typename T242 = void, typename T243 = void, typename T244 = void, typename T245 = void,
+						typename T246 = void, typename T247 = void, typename T248 = void, typename T249 = void,
+						typename T250 = void, typename T251 = void, typename T252 = void, typename T253 = void,
+						typename T254 = void, typename T255 = void, typename... Ts >
+
+						using f = typename indexed_builder<(sizeof...(Ts) > 16 ? 3 : 0)>::template f<rlist<
+						indexed<
+						indexed< T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>,
+						indexed< T16, T17, T18, T19, T20, T21, T22, T23, T24, T25, T26, T27, T28, T29, T30, T31>,
+						indexed< T32, T33, T34, T35, T36, T37, T38, T39, T40, T41, T42, T43, T44, T45, T46, T47>,
+						indexed< T48, T49, T50, T51, T52, T53, T54, T55, T56, T57, T58, T59, T60, T61, T62, T63>,
+
+						indexed< T64, T65, T66, T67, T68, T69, T70, T71, T72, T73, T74, T75, T76, T77, T78, T79>,
+						indexed< T80, T81, T82, T83, T84, T85, T86, T87, T88, T89, T90, T91, T92, T93, T94, T95>,
+						indexed< T96, T97, T98, T99, T100, T101, T102, T103, T104, T105, T106, T107, T108, T109, T110, T111>,
+						indexed< T112, T113, T114, T115, T116, T117, T118, T119, T120, T121, T122, T123, T124, T125, T126, T127>,
+
+						indexed< T128, T129, T130, T131, T132, T133, T134, T135, T136, T137, T138, T139, T140, T141, T142, T143>,
+						indexed< T144, T145, T146, T147, T148, T149, T150, T151, T152, T153, T154, T155, T156, T157, T158, T159>,
+						indexed< T160, T161, T162, T163, T164, T165, T166, T167, T168, T169, T170, T171, T172, T173, T174, T175>,
+						indexed< T176, T177, T178, T179, T180, T181, T182, T183, T184, T185, T186, T187, T188, T189, T190, T191>,
+
+						indexed< T192, T193, T194, T195, T196, T197, T198, T199, T200, T201, T202, T203, T204, T205, T206, T207>,
+						indexed< T208, T209, T210, T211, T212, T213, T214, T215, T216, T217, T218, T219, T220, T221, T222, T223>,
+						indexed< T224, T225, T226, T227, T228, T229, T230, T231, T232, T233, T234, T235, T236, T237, T238, T239>,
+						indexed< T240, T241, T242, T243, T244, T245, T246, T247, T248, T249, T250, T251, T252, T253, T254, T255>>, Out>, Ts...>;
+				};
+			}
+			template<typename...Ts>
+			using build_indexed = detail::indexed<typename detail::indexed_builder<(sizeof...(Ts)>16 ? 3 : 0)>::template f<detail::rlist<void, detail::rlist<void, detail::rlist<void, detail::rlist<void, detail::rlist<void, detail::rlist<void, detail::rlist<void, detail::rlist_tail_of8>>>>>>>, Ts...>>;
+			template<typename T, unsigned I>
+			using lookup = typename T::template f<detail::index<(I >> 8)>::template f>::template f<detail::index<((I >> 4) & 0xF)>::template f>::template f<detail::index<(I & 0xF)>::template f>;
+
+		}
+	}
+}

--- a/src/kvasir/mpl/algorithm/partition.hpp
+++ b/src/kvasir/mpl/algorithm/partition.hpp
@@ -17,6 +17,6 @@ namespace kvasir {
 		}
 
 		template <typename List, template <typename...> class Cond = identity>
-		using partition = c::call<c::partition<lambda<Cond>>, List>;
+		using partition = c::call<c::partition<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/remove_adjacent.hpp
+++ b/src/kvasir/mpl/algorithm/remove_adjacent.hpp
@@ -24,7 +24,7 @@ namespace kvasir {
 				template <template <typename...> class Pred, typename T, typename U, typename C = listify>
 				struct remove_adjacent;
 				template <template <typename...> class Pred, typename... Ts, typename... Us, typename C>
-					struct remove_adjacent<Pred, list<Ts...>, list<Us...>> {
+					struct remove_adjacent<Pred, list<Ts...>, list<Us...>, C> {
 					using type = typename dcall<join<C>, sizeof...(Ts)>::
 						template f<typename binary_list_if_not<Pred, Ts, Us>::type...>;
 				};
@@ -50,7 +50,7 @@ namespace kvasir {
 				using f = typename detail::remove_adjacent<F::template f, list<Ts...>, typename dcall<rotate<uint_<1>>,sizeof...(Ts)>::template f<Ts...>, C>::type;
 			};
 			template<template<typename...Ts> class F, typename C>
-			struct remove_adjacent<lambda<F>, C> {
+			struct remove_adjacent<cfe<F,identity>, C> {
 				template<typename...Ts>
 				using f = typename detail::remove_adjacent<F, list<Ts...>, typename dcall<rotate<uint_<1>>, sizeof...(Ts)>::template f<Ts...>, C>::type;
 			};
@@ -61,6 +61,6 @@ namespace kvasir {
 		/// if the predicate return true for any two adjacent elements,
 		/// then the first of the two elements is removed
 		template <typename List, template <typename...> class Pred = std::is_same>
-		using remove_adjacent = c::call<c::remove_adjacent<lambda<Pred>>, List>;
+		using remove_adjacent = c::call<c::remove_adjacent<c::cfe<Pred>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/remove_if.hpp
+++ b/src/kvasir/mpl/algorithm/remove_if.hpp
@@ -32,8 +32,8 @@ namespace kvasir {
 				template <typename T>
 				using f = typename detail::list_wrap_if<F::template f<T>::value>::template f<T>;
 			};
-			template <template <typename...> class F>
-			struct list_wrap_if<lambda<F>> {
+			template <template <typename> class F>
+			struct list_wrap_if<cfe<F,identity>> {
 				template <typename T>
 				using f = typename detail::list_wrap_if<F<T>::value>::template f<T>;
 			};
@@ -42,8 +42,8 @@ namespace kvasir {
 				template <typename T>
 				using f = typename detail::list_wrap_if<(!F::template f<T>::value)>::template f<T>;
 			};
-			template <template <typename...> class F>
-			struct list_wrap_if_not<lambda<F>> {
+			template <template <typename> class F>
+			struct list_wrap_if_not<cfe<F,identity>> {
 				template <typename T>
 				using f = typename detail::list_wrap_if<(!F<T>::value)>::template f<T>;
 			};
@@ -56,6 +56,6 @@ namespace kvasir {
 		/// filter elements from a list
 		/// takes a lambda that should return a type convertible to bool
 		template <typename List, template <typename...> class Cond = identity>
-		using remove_if = c::call<c::remove_if<lambda<Cond>>, List>;
+		using remove_if = c::call<c::remove_if<c::cfe<Cond>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/replace_if.hpp
+++ b/src/kvasir/mpl/algorithm/replace_if.hpp
@@ -20,7 +20,7 @@ namespace kvasir {
 					using f = typename conditional<F::template f<T>::value>::template f<Input, T>;
 				};
 				template<template <typename...> class F, typename Input>
-				struct replace_if_pred<lambda<F>,Input> {
+				struct replace_if_pred<cfe<F,identity>,Input> {
 					template <typename T>
 					using f = typename conditional<F<T>::value>::template f<Input, T>;
 				};
@@ -31,6 +31,6 @@ namespace kvasir {
 		}
 
 		template <typename List, typename Input, template <typename...> class Cond = identity>
-		using replace_if = c::call<c::replace_if<lambda<Cond>, Input>, List>;
+		using replace_if = c::call<c::replace_if<c::cfe<Cond>, Input>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/split_if.hpp
+++ b/src/kvasir/mpl/algorithm/split_if.hpp
@@ -9,6 +9,7 @@
 #include "../algorithm/fold_right.hpp"
 #include "../functional/call.hpp"
 #include "../types/list.hpp"
+#include "../sequence/push_front.hpp"
 
 namespace kvasir {
 	namespace mpl {

--- a/src/kvasir/mpl/algorithm/split_if.hpp
+++ b/src/kvasir/mpl/algorithm/split_if.hpp
@@ -38,11 +38,10 @@ namespace kvasir {
 			template<typename F, typename C = listify>
 			struct split_if {
 				template<typename...Ts>
-				using f = typename dcall<c::fold_right<detail::split_if_pred<F::template f>,push_front<C,bind2<call>>>, sizeof...(Ts)>::template f<list<list<>>, Ts...>;
+				using f = typename dcall<c::fold_right<detail::split_if_pred<F::template f>,push_front<C,c::cfe<call>>>, sizeof...(Ts)>::template f<list<list<>>, Ts...>;
 			};
 		}
 		template <typename List, template <typename...> class F>
-		using split_if =
-		        c::call<c::split_if<bind0n<F>>, List>;
+		using split_if = c::call<c::split_if<c::cfe<F>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/split_if.hpp
+++ b/src/kvasir/mpl/algorithm/split_if.hpp
@@ -29,7 +29,7 @@ namespace kvasir {
 					using type = list<list<>, Ls...>;
 				};
 
-				template <template <typename> class F>
+				template <template <typename...> class F>
 				struct split_if_pred {
 					template <typename T, typename U>
 					using f = typename std::conditional<F<U>::value, split_next<T>,

--- a/src/kvasir/mpl/algorithm/split_if.hpp
+++ b/src/kvasir/mpl/algorithm/split_if.hpp
@@ -12,31 +12,37 @@
 
 namespace kvasir {
 	namespace mpl {
-		namespace detail {
-			template <typename T, typename U>
-			struct split_push;
-			template <typename... Ls, typename... Ts, typename U>
-			struct split_push<list<list<Ts...>, Ls...>, U> {
-				using type = list<list<U, Ts...>, Ls...>;
-			};
-
-			template <typename T>
-			struct split_next;
-			template <typename... Ls>
-			struct split_next<list<Ls...>> {
-				using type = list<list<>, Ls...>;
-			};
-
-			template <template <typename...> class F>
-			struct split_if_pred {
+		namespace c {
+			namespace detail {
 				template <typename T, typename U>
-				using f = typename std::conditional<F<U>::value, split_next<T>,
-				                                    split_push<T, U>>::type::type;
+				struct split_push;
+				template <typename... Ls, typename... Ts, typename U>
+				struct split_push<list<list<Ts...>, Ls...>, U> {
+					using type = list<list<U, Ts...>, Ls...>;
+				};
+
+				template <typename T>
+				struct split_next;
+				template <typename... Ls>
+				struct split_next<list<Ls...>> {
+					using type = list<list<>, Ls...>;
+				};
+
+				template <template <typename> class F>
+				struct split_if_pred {
+					template <typename T, typename U>
+					using f = typename std::conditional<F<U>::value, split_next<T>,
+						split_push<T, U>>::type::type;
+				};
+			}
+			template<typename F, typename C = listify>
+			struct split_if {
+				template<typename...Ts>
+				using f = typename dcall<c::fold_right<detail::split_if_pred<F::template f>,push_front<C,bind2<call>>>, sizeof...(Ts)>::template f<list<list<>>, Ts...>;
 			};
 		}
 		template <typename List, template <typename...> class F>
 		using split_if =
-		        c::call<c::fold_right<detail::split_if_pred<F>>,
-		                List, list<list<>>>;
+		        c::call<c::split_if<bind0n<F>>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/transform.hpp
+++ b/src/kvasir/mpl/algorithm/transform.hpp
@@ -19,17 +19,17 @@ namespace kvasir {
 				using f = KVASIR_D_CALL(C, Ts)<typename F::template f<Ts>...>;
 			};
 			template <template <typename...> class F, typename C>
-			struct transform<lambda<F>, C> {
+			struct transform<cfe<F, identity>, C> {
 				template <typename... Ts>
 				using f = typename C::template f<F<Ts>...>;
 			};
 			template <template <typename...> class F, template <typename...> class C>
-			struct transform<lambda<F>, lambda<C>> {
+			struct transform<cfe<F, identity>, cfe<C, identity>> {
 				template <typename... Ts>
 				using f = C<F<Ts>...>;
 			};
 			template <typename F, template <typename...> class C>
-			struct transform<F, lambda<C>> {
+			struct transform<F, cfe<C, identity>> {
 				template <typename... Ts>
 				using f = C<typename F::template f<Ts>...>;
 			};
@@ -37,6 +37,6 @@ namespace kvasir {
 
 		/// transform each element in a list with a function
 		template <typename List, template <typename...> class F>
-		using transform = c::call<c::transform<lambda<F>, c::listify>, List>;
+		using transform = c::call<c::transform<c::cfe<F>, c::listify>, List>;
 	}
 }

--- a/src/kvasir/mpl/algorithm/transform.hpp
+++ b/src/kvasir/mpl/algorithm/transform.hpp
@@ -21,7 +21,7 @@ namespace kvasir {
 			template <template <typename...> class F, typename C>
 			struct transform<cfe<F, identity>, C> {
 				template <typename... Ts>
-				using f = typename C::template f<F<Ts>...>;
+				using f = typename dcall<C, sizeof...(Ts)>::template f<typename dcallf<bool(sizeof...(Ts))>::template f1<F, Ts>...>;
 			};
 			template <template <typename...> class F, template <typename...> class C>
 			struct transform<cfe<F, identity>, cfe<C, identity>> {

--- a/src/kvasir/mpl/algorithm/zip_with.hpp
+++ b/src/kvasir/mpl/algorithm/zip_with.hpp
@@ -26,21 +26,21 @@ namespace kvasir {
 				template <typename F, typename C, template <typename...> class Seq, typename... L0s,
 				          typename... L1s>
 				struct call_impl<zip_with<F, C>, Seq<L0s...>, Seq<L1s...>> {
-					using type = typename detail::make_bound<C>::template f<
-					        typename detail::make_bound<F>::template f<L0s, L1s>...>;
+					using type = typename dcall<C,sizeof...(L0s)>::template f<
+					        typename dcall<F,sizeof...(L0s)>::template f<L0s, L1s>...>;
 				};
 				template <typename F, typename C, template <typename...> class Seq, typename... L0s,
 				          typename... L1s, typename... L2s>
 				struct call_impl<zip_with<F, C>, Seq<L0s...>, Seq<L1s...>, Seq<L2s...>> {
-					using type = typename detail::make_bound<C>::template f<
-					        typename detail::make_bound<F>::template f<L0s, L1s, L2s>...>;
+					using type = typename C::template f<
+					        typename dcall<F, sizeof...(L0s)>::template f<L0s, L1s, L2s>...>;
 				};
 				template <typename F, typename C, template <typename...> class Seq, typename... L0s,
 				          typename... L1s, typename... L2s, typename... L3s>
 				struct call_impl<zip_with<F, C>, Seq<L0s...>, Seq<L1s...>, Seq<L2s...>,
 				                 Seq<L3s...>> {
-					using type = typename detail::make_bound<C>::template f<
-					        typename detail::make_bound<F>::template f<L0s, L1s, L2s, L3s>...>;
+					using type = typename C::template f<
+					        typename dcall<F, sizeof...(L0s)>::template f<L0s, L1s, L2s, L3s>...>;
 				};
 			}
 		}

--- a/src/kvasir/mpl/compatability/dependent_call.hpp
+++ b/src/kvasir/mpl/compatability/dependent_call.hpp
@@ -12,44 +12,32 @@ namespace kvasir {
 		namespace c {
 			template<typename C, unsigned size>
 			using dcall = typename conditional<(size<100000)>::template f<C, void>;
+
+
+			template<bool>
+			struct dcallf;
+			template<>
+			struct dcallf<true> {
+				template<template<typename...> class F1, typename...Ts>
+				using f1 = F1<Ts...>;
+				template<template<typename...> class F1, template<typename...> class F2, typename...Ts>
+				using f2 = F1<F2<Ts...>>;
+			};
+			template<>
+			struct dcallf<false> {
+				template<template<typename...> class F1, typename...Ts>
+				using f1 = F1<>;
+				template<template<typename...> class F1, template<typename...> class F2, typename...Ts>
+				using f2 = F1<F2<>>;
+			};
+
+
+			
 		}
 	}
 }
-
-#if defined(KVASIR_MSVC_2017) || defined(KVASIR_MSVC_2015) || defined(KVASIR_MSVC_2013) || \
-        defined(KVASIR_CLANG_35) || defined(KVASIR_CLANG_36) || defined(KVASIR_CLANG_37)
-#include <limits>
-
-#include "../functional/bind.hpp"
-
-namespace kvasir {
-	namespace mpl {
-		namespace c {
-			namespace detail {
-				constexpr bool always_true(const std::size_t in) {
-					return in < std::numeric_limits<std::size_t>::max();
-				}
-				template <template <typename...> class F, typename... Ts>
-				struct lazify {
-					using type = F<Ts...>;
-				};
-				template <typename T, bool I>
-				struct dependent_call {};
-
-				template <typename T>
-				struct dependent_call<T, true> : T {};
-
-			}
-		}
-	}
-}
-#define KVASIR_D_CALL(Continuation, Pack)              \
-	typename ::kvasir::mpl::c::detail::dependent_call< \
-	        Continuation, ::kvasir::mpl::c::detail::always_true(sizeof...(Pack))>::template f
-
-#else
 
 #define KVASIR_D_CALL(T, Pack) typename ::kvasir::mpl::c::dcall<T,sizeof...(Pack)>::template f
 
-#endif
+
 

--- a/src/kvasir/mpl/compatability/dependent_call.hpp
+++ b/src/kvasir/mpl/compatability/dependent_call.hpp
@@ -39,11 +39,6 @@ namespace kvasir {
 				template <typename T>
 				struct dependent_call<T, true> : T {};
 
-				template <template <typename...> class F, typename... As>
-				struct dependent_call<bind0n<F, As...>, true> {
-					template <typename... Ts>
-					using f = typename lazify<F, As..., Ts...>::type;
-				};
 			}
 		}
 	}

--- a/src/kvasir/mpl/functional/bind.hpp
+++ b/src/kvasir/mpl/functional/bind.hpp
@@ -4,6 +4,8 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include "../functional/identity.hpp"
+
 namespace kvasir {
 	namespace mpl {
 		/// bind a function object to a type so that it can be returned or stored in a list
@@ -12,58 +14,73 @@ namespace kvasir {
 		/// be either extracted from the type, or to be processed and used at a later stage.
 		/// It is however possible to add parameters to the function before execution, so that
 		/// they will be prepended to the function arguments when it is called.
-		template <template <typename...> class Func, typename... Args>
-		struct bind0n { // takes pack of 0-n elements
-			template <typename... T>
-			using f = Func<Args..., T...>;
-		};
-		template <template <typename...> class Func, typename... Args>
-		struct bind1 {
-			template <typename T>
-			using f = Func<Args..., T>;
-		};
-		template <template <typename...> class Func, typename... Args>
-		struct bind1n { // takes pack of 1-n elements
-			template <typename T, typename... Ts>
-			using f = Func<Args..., T, Ts...>;
-		};
-		template <template <typename...> class Func, typename... Args>
-		struct bind2 {
-			template <typename T, typename U>
-			using f = Func<Args..., T, U>;
-		};
-		template <template <typename...> class Func, typename... Args>
-		struct bind2n { // takes pack of 2-n elements
-			template <typename T, typename U, typename... Ts>
-			using f = Func<Args..., T, U, Ts...>;
-		};
-		template <template <typename...> class F, typename... As>
-		struct bind_t {
-			template <typename... Ts>
-			using f = typename F<As..., Ts...>::type;
-		};
-		template <template <typename...> class F>
-		struct lambda {};
+		//template <template <typename...> class Func, typename... Args>
+		//struct bind0n { // takes pack of 0-n elements
+		//	template <typename... T>
+		//	using f = Func<Args..., T...>;
+		//};
+		//template <template <typename...> class Func, typename... Args>
+		//struct bind1 {
+		//	template <typename T>
+		//	using f = Func<Args..., T>;
+		//};
+		//template <template <typename...> class Func, typename... Args>
+		//struct bind1n { // takes pack of 1-n elements
+		//	template <typename T, typename... Ts>
+		//	using f = Func<Args..., T, Ts...>;
+		//};
+		//template <template <typename...> class Func, typename... Args>
+		//struct bind2 {
+		//	template <typename T, typename U>
+		//	using f = Func<Args..., T, U>;
+		//};
+		//template <template <typename...> class Func, typename... Args>
+		//struct bind2n { // takes pack of 2-n elements
+		//	template <typename T, typename U, typename... Ts>
+		//	using f = Func<Args..., T, U, Ts...>;
+		//};
+		//template <template <typename...> class F, typename... As>
+		//struct bind_t {
+		//	template <typename... Ts>
+		//	using f = typename F<As..., Ts...>::type;
+		//};
+		//template <template <typename...> class F>
+		//struct lambda {};
 		namespace c {
-			using mpl::bind0n;
-			using mpl::bind1;
-			using mpl::bind1n;
-			using mpl::bind2;
-			using mpl::bind2n;
-			using mpl::lambda;
-			using mpl::bind_t;
+			template<template<typename...> class F, typename C = identity>
+			struct cfl {
+				template<typename...Ts>
+				using f = typename C::template f<typename F<Ts...>::type>;
+			};
+			template<template<typename...> class F>
+			struct cfl<F, identity> {
+				template<typename...Ts>
+				using f = typename F<Ts...>::type;
+			};
+
+			template<template<typename...> class F, typename C = identity>
+			struct cfe {
+				template<typename...Ts>
+				using f = typename C::template f<F<Ts...>>;
+			};
+			template<template<typename...> class F>
+			struct cfe<F, identity> {
+				template<typename...Ts>
+				using f = F<Ts...>;
+			};
+
 
 			// helper for functions that cannot specialize to detect lambda wrapped types
 			// this is handy but will be slower
-			namespace detail {
-				template <typename T>
-				struct make_bound : T {};
-				template <template <typename...> class F>
-				struct make_bound<lambda<F>> {
-					template <typename... Ts>
-					using f = F<Ts...>;
-				};
-			}
+			//namespace detail {
+			//	template <typename T>
+			//	struct make_bound : T {};
+			//	template <template <typename...> class F>
+			//	struct make_bound<lambda<F>> {
+			//		template <typename... Ts>
+			//		using f = F<Ts...>;
+			//	};
+			//}
 		}
 	}
 }

--- a/src/kvasir/mpl/functional/bind.hpp
+++ b/src/kvasir/mpl/functional/bind.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "../functional/identity.hpp"
+#include "../compatability/dependent_call.hpp"
 
 namespace kvasir {
 	namespace mpl {
@@ -66,7 +67,7 @@ namespace kvasir {
 			template<template<typename...> class F>
 			struct cfe<F, identity> {
 				template<typename...Ts>
-				using f = F<Ts...>;
+				using f = typename dcallf<bool(sizeof...(Ts))>::template f1<F,Ts...>;
 			};
 
 

--- a/src/kvasir/mpl/functional/call.hpp
+++ b/src/kvasir/mpl/functional/call.hpp
@@ -22,8 +22,8 @@ namespace kvasir {
 				template <typename R, typename... C, template <typename...> class Seq,
 				          typename... Ls>
 				struct call_impl<fork<R, C...>, Seq<Ls...>> {
-					using type = typename detail::make_bound<R>::template f<
-					        typename detail::make_bound<C>::template f<Ls...>...>;
+					using type = typename dcall<R,sizeof...(C)>::template f<
+					        typename dcall<C,sizeof...(Ls)>::template f<Ls...>...>;
 				};
 			}
 			template <typename C, typename L, typename... Ls>

--- a/src/kvasir/mpl/functional/call.hpp
+++ b/src/kvasir/mpl/functional/call.hpp
@@ -22,8 +22,7 @@ namespace kvasir {
 				template <typename R, typename... C, template <typename...> class Seq,
 				          typename... Ls>
 				struct call_impl<fork<R, C...>, Seq<Ls...>> {
-					using type = typename dcall<R,sizeof...(C)>::template f<
-					        typename dcall<C,sizeof...(Ls)>::template f<Ls...>...>;
+					using type = typename R::template f<typename C::template f<Ls...>...>;
 				};
 			}
 			template <typename C, typename L, typename... Ls>

--- a/src/kvasir/mpl/functional/fork.hpp
+++ b/src/kvasir/mpl/functional/fork.hpp
@@ -11,8 +11,8 @@ namespace kvasir {
 			template <typename Combiner, typename... Cs>
 			struct fork {
 				template <typename... Ts>
-				using f = typename detail::make_bound<Combiner>::template f<
-				        typename detail::make_bound<Cs>::template f<Ts...>...>;
+				using f = typename dcall<Combiner,sizeof...(Cs)>::template f<
+				        typename dcall<Cs,sizeof...(Ts)>::template f<Ts...>...>;
 			};
 		}
 	}

--- a/src/kvasir/mpl/functional/identity.hpp
+++ b/src/kvasir/mpl/functional/identity.hpp
@@ -6,6 +6,12 @@
 
 namespace kvasir {
 	namespace mpl {
+		namespace c {
+			struct identity {
+				template <typename T>
+				using f = T;
+			};
+		}
 		template <typename T>
 		using identity = T;
 	}

--- a/src/kvasir/mpl/mpl.hpp
+++ b/src/kvasir/mpl/mpl.hpp
@@ -82,4 +82,5 @@
 
 #include "utility/always.hpp"
 #include "utility/conditional.hpp"
+#include "utility/is_same.hpp"
 #include "utility/is_instance.hpp"

--- a/src/kvasir/mpl/mpl.hpp
+++ b/src/kvasir/mpl/mpl.hpp
@@ -14,6 +14,7 @@
 #include "algorithm/fold_left.hpp"
 #include "algorithm/fold_right.hpp"
 #include "algorithm/insert.hpp"
+#include "algorithm/lookup.hpp"
 #include "algorithm/make_sequence.hpp"
 #include "algorithm/partition.hpp"
 #include "algorithm/remove_adjacent.hpp"

--- a/src/kvasir/mpl/sequence/join.hpp
+++ b/src/kvasir/mpl/sequence/join.hpp
@@ -1650,7 +1650,7 @@ namespace kvasir {
 				        sizeof...(Ts))>::template f<C::template f, Ts...>;
 			};
 			template <template <typename...> class C>
-			struct join<lambda<C>> {
+			struct join<cfe<C,identity>> {
 				template <typename... Ts>
 				using f = typename detail::join_select<detail::select_join_size(
 				        sizeof...(Ts))>::template f<C, Ts...>;
@@ -1661,7 +1661,7 @@ namespace kvasir {
 				using f = typename detail::recursive_join_impl<C::template f, T>::type;
 			};
 			template <template <typename...> class C>
-			struct recursive_join<lambda<C>> {
+			struct recursive_join<cfe<C,identity>> {
 				template <typename T>
 				using f = typename detail::recursive_join_impl<C, T>::type;
 			};

--- a/src/kvasir/mpl/sequence/push_back.hpp
+++ b/src/kvasir/mpl/sequence/push_back.hpp
@@ -8,6 +8,13 @@
 
 namespace kvasir {
 	namespace mpl {
+		namespace c {
+			template<typename Input, typename C = listify>
+			struct push_back {
+				template<typename...Ts>
+				using f = KVASIR_D_CALL(C, Ts) <Ts..., Input >;
+			};
+		}
 		namespace impl {
 			template <typename Elem, typename List>
 			struct push_back_impl {

--- a/src/kvasir/mpl/sequence/push_front.hpp
+++ b/src/kvasir/mpl/sequence/push_front.hpp
@@ -10,7 +10,7 @@
 namespace kvasir {
 	namespace mpl {
 		namespace c {
-			template<typename Input, typename C>
+			template<typename Input, typename C = listify>
 			struct push_front {
 				template<typename...Ts>
 				using f = KVASIR_D_CALL(C, Ts) <Input, Ts... >;

--- a/src/kvasir/mpl/types/list.hpp
+++ b/src/kvasir/mpl/types/list.hpp
@@ -13,6 +13,7 @@ namespace kvasir {
 				// recursive list, for internal use only
 				template <typename Head, typename Tail>
 				struct rlist {};
+
 				using rlist_tail_of8 = rlist<
 				        list<>,
 				        rlist<list<>,

--- a/src/kvasir/mpl/types/list.hpp
+++ b/src/kvasir/mpl/types/list.hpp
@@ -23,13 +23,13 @@ namespace kvasir {
 				                                rlist<list<>,
 				                                      rlist<list<>, rlist<list<>, void>>>>>>>>;
 			}
-			using listify = bind0n<list>;
+			using listify = cfe<list>;
 
 			template <typename S>
 			struct sequencify;
 			template <template <typename...> class S, typename... Ts>
 			struct sequencify<S<Ts...>> {
-				using type = bind0n<S>;
+				using type = cfe<S>;
 			};
 		}
 

--- a/src/kvasir/mpl/utility/is_same.hpp
+++ b/src/kvasir/mpl/utility/is_same.hpp
@@ -1,0 +1,33 @@
+//          Copyright Chiel Douwes 2017.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE.md or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+#pragma once
+#include<type_traits>
+#include "../functional/identity.hpp"
+namespace kvasir {
+	namespace mpl {
+		namespace c {
+			template <typename C = identity>
+			struct is_same {
+				template<typename T, typename U>
+				using f = typename C::template f<std::is_same<T,U>>;
+			};
+			template <>
+			struct is_same<identity> {
+				template<typename T, typename U>
+				using f = std::is_same<T,U>;
+			};
+			template <typename M, typename C = identity>
+			struct same_as {
+				template<typename T>
+				using f = typename C::template f<std::is_same<M, T>>;
+			};
+			template <typename M>
+			struct same_as<M, identity> {
+				template<typename T>
+				using f = std::is_same<M, T>;
+			};
+		}
+	}
+}

--- a/test/algorithm/find_if.hpp
+++ b/test/algorithm/find_if.hpp
@@ -8,11 +8,12 @@
 
 #include <kvasir/mpl/algorithm/find_if.hpp>
 #include <kvasir/mpl/functional/bind.hpp>
+#include <kvasir/mpl/utility/is_same.hpp>
 
 namespace {
 	using namespace kvasir;
 	static_assert(std::is_same<mpl::find_if<mpl::list<void, char, short, int>,
-	                                        mpl::bind1<std::is_same, char>::template f>,
+	                                        mpl::c::same_as<char>::template f>,
 	                           mpl::list<char, short, int>>{},
 	              "");
 }

--- a/test/algorithm/fold_right.hpp
+++ b/test/algorithm/fold_right.hpp
@@ -9,6 +9,7 @@
 #include <kvasir/mpl/algorithm/fold_right.hpp>
 #include <kvasir/mpl/types/int.hpp>
 #include <kvasir/mpl/types/list.hpp>
+#include <kvasir/mpl/functional/bind.hpp>
 
 namespace {
 	namespace mpl = kvasir::mpl;
@@ -30,33 +31,33 @@ namespace {
 	              "");
 
 	static_assert(std::is_same<mpl::fold_right<mpl::list<uint_<1>, uint_<2>>, mpl::list<>,
-	                                           mpl::bind_t<push>::template f>,
+	                                           mpl::c::cfl<push>::template f>,
 	                           mpl::list<uint_<1>, uint_<2>>>::value,
 	              "");
 	static_assert(std::is_same<mpl::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>>, mpl::list<>,
-	                                           mpl::bind_t<push>::template f>,
+												mpl::c::cfl<push>::template f>,
 	                           mpl::list<uint_<1>, uint_<2>, uint_<3>>>::value,
 	              "");
 	static_assert(std::is_same<mpl::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>,
-	                                           mpl::list<>, mpl::bind_t<push>::template f>,
+	                                           mpl::list<>, mpl::c::cfl<push>::template f>,
 	                           mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>>::value,
 	              "");
 	static_assert(
 	        std::is_same<
 	                mpl::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>>,
-	                                mpl::list<>, mpl::bind_t<push>::template f>,
+	                                mpl::list<>, mpl::c::cfl<push>::template f>,
 	                mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>>>::value,
 	        "");
 	static_assert(
 	        std::is_same<
 	                mpl::fold_right<
 	                        mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>>,
-	                        mpl::list<>, mpl::bind_t<push>::template f>,
+	                        mpl::list<>, mpl::c::cfl<push>::template f>,
 	                mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>>>::value,
 	        "");
 	static_assert(std::is_same<mpl::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>,
 	                                                     uint_<5>, uint_<6>, uint_<7>>,
-	                                           mpl::list<>, mpl::bind_t<push>::template f>,
+	                                           mpl::list<>, mpl::c::cfl<push>::template f>,
 	                           mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>,
 	                                     uint_<7>>>::value,
 	              "");

--- a/test/algorithm/zip_with.hpp
+++ b/test/algorithm/zip_with.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <kvasir/mpl/algorithm/zip_with.hpp>
+#include <kvasir/mpl/functional/bind.hpp>
 
 namespace {
 	namespace mpl  = kvasir::mpl;
@@ -14,7 +15,7 @@ namespace {
 	                                                                                    char>,
 	                           mpl::list<int, short>>;
 	static_assert(std::is_same<mpl::zip_with<mpl::list, zip_a, zip_b>, zip_shoud_be>::value, "");
-	static_assert(std::is_same<mpl::c::call<mpl::c::zip_with<mpl::lambda<mpl::list>>, zip_a, zip_b>,
+	static_assert(std::is_same<mpl::c::call<mpl::c::zip_with<mpl::c::cfe<mpl::list>>, zip_a, zip_b>,
 	                           zip_shoud_be>::value,
 	              "");
 }


### PR DESCRIPTION
Moving away from the bind-... syntax for a more portable and faster version that allows for continuations in function calls.