### PR TITLE
Add ucall to automatically unpack lists.

### DIFF
--- a/src/kvasir/mpl/functional/call.hpp
+++ b/src/kvasir/mpl/functional/call.hpp
@@ -29,6 +29,10 @@ namespace kvasir {
 		template <typename C, typename... Ts>
 		using call = typename dcall<C, sizeof...(Ts)>::template f<Ts...>;
 
+		/// \brief call a continuation (left parameter) with a list
+		template <typename C, typename... Ts>
+		using ucall = typename dcall<unpack<C>, sizeof...(Ts)>::template f<Ts...>;
+
 		template <typename C = identity>
 		struct call_f {
 			template <typename... Ts>


### PR DESCRIPTION
I couldn't find a `ucall` in the documentation. Is it under a different name? In Odin's blog he calls it `ucall` so that's what I was expecting. This is a handy thing to have sitting around since it reduces the amount of code needed by quite a bit in some cases.