### PR TITLE
Add compatibility for gcc-4.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
+          packages: ['g++-4.7', 'cmake', 'cmake-data']
+      env: TOOLSET=g++-4.7
+
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'george-edison55-precise-backports']
           packages: ['g++-4.8', 'cmake', 'cmake-data']
       env: TOOLSET=g++-4.8
 

--- a/src/kvasir/mpl/algorithm/flatten.hpp
+++ b/src/kvasir/mpl/algorithm/flatten.hpp
@@ -16,9 +16,8 @@ namespace kvasir {
 
 			template <template <class...> class L, class... Ts>
 			struct flatten_element_impl<L, L<Ts...>> {
-				using type = typename detail::join_select<detail::select_join_size(sizeof...(
-				        Ts))>::template f<list,
-				                          typename flatten_element_impl<L, Ts>::type...>::type;
+				using type = typename detail::join_select<detail::select_join_size(sizeof...(Ts))>::
+				        template f<list, typename flatten_element_impl<L, Ts>::type...>::type;
 			};
 		} // namespace detail
 		/// \brief converts a tree or list of lists into one list containing the contents of all

--- a/src/kvasir/mpl/algorithm/sort.hpp
+++ b/src/kvasir/mpl/algorithm/sort.hpp
@@ -27,8 +27,8 @@ namespace kvasir {
 			template <class... R, class T0, class T1, class... Ts, class U, class... Us,
 			          template <typename...> class Comp>
 			struct merge_insert<true, list<R...>, list<T0, T1, Ts...>, list<U, Us...>, Comp>
-			    : merge_insert<Comp<T1, U>::value, list<R..., T0>, list<T1, Ts...>, list<U, Us...>,
-			                   Comp> {};
+			        : merge_insert<Comp<T1, U>::value, list<R..., T0>, list<T1, Ts...>,
+			                       list<U, Us...>, Comp> {};
 
 			template <class... R, class T, class U, class... Us, template <typename...> class Comp>
 			struct merge_insert<true, list<R...>, list<T>, list<U, Us...>, Comp> {
@@ -40,8 +40,8 @@ namespace kvasir {
 			template <class... R, class T, class... Ts, class U0, class U1, class... Us,
 			          template <typename...> class Comp>
 			struct merge_insert<false, list<R...>, list<T, Ts...>, list<U0, U1, Us...>, Comp>
-			    : merge_insert<Comp<T, U1>::value, list<R..., U0>, list<T, Ts...>, list<U1, Us...>,
-			                   Comp> {};
+			        : merge_insert<Comp<T, U1>::value, list<R..., U0>, list<T, Ts...>,
+			                       list<U1, Us...>, Comp> {};
 
 			template <class... R, class T, class... Ts, class U, template <typename...> class Comp>
 			struct merge_insert<false, list<R...>, list<T, Ts...>, list<U>, Comp> {
@@ -56,9 +56,9 @@ namespace kvasir {
 			          class U9, class... Us, template <typename...> class Comp>
 			struct merge_impl<list<R...>, list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, Ts...>,
 			                  list<U0, U1, U2, U3, U4, U5, U6, U7, U8, U9, Us...>, Comp> {
-				using sub  = merge_insert<Comp<T0, U0>::value, list<>,
-                                         list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>,
-                                         list<U0, U1, U2, U3, U4, U5, U6, U7, U8, U9>, Comp>;
+				using sub = merge_insert<Comp<T0, U0>::value, list<>,
+				                         list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>,
+				                         list<U0, U1, U2, U3, U4, U5, U6, U7, U8, U9>, Comp>;
 				using type = typename merge_impl<
 				        typename join<listify>::template f<list<R...>, typename sub::out>,
 				        typename join<listify>::template f<typename sub::left, list<Ts...>>,
@@ -69,10 +69,11 @@ namespace kvasir {
 			template <class... R, class T, class... Ts, class U, class... Us,
 			          template <typename...> class Comp>
 			struct merge_impl<list<R...>, list<T, Ts...>, list<U, Us...>, Comp>
-			    : std::conditional<
-			              Comp<T, U>::value,
-			              merge_impl<list<R..., T>, list<Ts...>, list<U, Us...>, Comp>,
-			              merge_impl<list<R..., U>, list<T, Ts...>, list<Us...>, Comp>>::type {};
+			        : std::conditional<
+			                  Comp<T, U>::value,
+			                  merge_impl<list<R..., T>, list<Ts...>, list<U, Us...>, Comp>,
+			                  merge_impl<list<R..., U>, list<T, Ts...>, list<Us...>, Comp>>::type {
+			};
 
 			template <class... R, class... Ts, template <typename...> class Comp>
 			struct merge_impl<list<R...>, list<Ts...>, list<>, Comp> {
@@ -98,25 +99,25 @@ namespace kvasir {
 			template <class T0, class T1, class T2, class T3, class T4, class T5, class T6,
 			          class T7, class T8, class... Ts, template <typename...> class Comp>
 			struct mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7, T8, Ts...>, Comp>
-			    : merge_impl<list<>,
-			                 typename mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7>, Comp>::type,
-			                 typename mini_sort<list<T8, Ts...>, Comp>::type, Comp> {};
+			        : merge_impl<list<>, typename mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7>,
+			                                                Comp>::type,
+			                     typename mini_sort<list<T8, Ts...>, Comp>::type, Comp> {};
 
 			template <class T0, class T1, class T2, class T3, class T4, class... Ts,
 			          template <typename...> class Comp>
 			struct mini_sort<list<T0, T1, T2, T3, T4, Ts...>, Comp>
-			    : merge_impl<list<>, typename mini_sort<list<T0, T1, T2, T3>, Comp>::type,
-			                 typename mini_sort<list<T4, Ts...>, Comp>::type, Comp> {};
+			        : merge_impl<list<>, typename mini_sort<list<T0, T1, T2, T3>, Comp>::type,
+			                     typename mini_sort<list<T4, Ts...>, Comp>::type, Comp> {};
 
 			template <class T0, class T1, class T2, class T3, template <typename...> class Comp>
 			struct mini_sort<list<T0, T1, T2, T3>, Comp>
-			    : merge_impl<list<>, typename mini_sort<list<T0, T1>, Comp>::type,
-			                 typename mini_sort<list<T2, T3>, Comp>::type, Comp> {};
+			        : merge_impl<list<>, typename mini_sort<list<T0, T1>, Comp>::type,
+			                     typename mini_sort<list<T2, T3>, Comp>::type, Comp> {};
 
 			template <class T0, class T1, class T2, template <typename...> class Comp>
 			struct mini_sort<list<T0, T1, T2>, Comp>
-			    : merge_impl<list<>, typename mini_sort<list<T0, T1>, Comp>::type, list<T2>, Comp> {
-			};
+			        : merge_impl<list<>, typename mini_sort<list<T0, T1>, Comp>::type, list<T2>,
+			                     Comp> {};
 
 			template <class T0, class T1, template <typename...> class Comp>
 			struct mini_sort<list<T0, T1>, Comp> {
@@ -134,58 +135,55 @@ namespace kvasir {
 			          class T7, class T8, class T9, class T10, class T11, class T12, class T13,
 			          class T14, class T15, class T16, class T17, class... Ts,
 			          template <typename...> class Comp>
-			struct sort_impl<list<>,
-			                 list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
-			                      T15, T16, T17, Ts...>,
+			struct sort_impl<list<>, list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+			                              T13, T14, T15, T16, T17, Ts...>,
 			                 Comp>
-			    : sort_impl<list<typename mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9,
-			                                             T10, T11, T12, T13, T14, T15, T16, T17>,
-			                                        Comp>::type>,
-			                list<Ts...>, Comp> {};
+			        : sort_impl<
+			                  list<typename mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9,
+			                                               T10, T11, T12, T13, T14, T15, T16, T17>,
+			                                          Comp>::type>,
+			                  list<Ts...>, Comp> {};
 
 			template <class L0, class T0, class T1, class T2, class T3, class T4, class T5,
 			          class T6, class T7, class T8, class T9, class T10, class T11, class T12,
 			          class T13, class T14, class T15, class T16, class T17, class... Ts,
 			          template <typename...> class Comp>
-			struct sort_impl<list<L0>,
-			                 list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
-			                      T15, T16, T17, Ts...>,
+			struct sort_impl<list<L0>, list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+			                                T13, T14, T15, T16, T17, Ts...>,
 			                 Comp>
-			    : sort_impl<
-			              list<L0, typename mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9,
-			                                               T10, T11, T12, T13, T14, T15, T16, T17>,
-			                                          Comp>::type>,
-			              list<Ts...>, Comp> {};
+			        : sort_impl<list<L0, typename mini_sort<
+			                                     list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
+			                                          T11, T12, T13, T14, T15, T16, T17>,
+			                                     Comp>::type>,
+			                    list<Ts...>, Comp> {};
 
 			template <class L0, class L1, class T0, class T1, class T2, class T3, class T4,
 			          class T5, class T6, class T7, class T8, class T9, class T10, class T11,
 			          class T12, class T13, class T14, class T15, class T16, class T17, class... Ts,
 			          template <typename...> class Comp>
-			struct sort_impl<list<L0, L1>,
-			                 list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
-			                      T15, T16, T17, Ts...>,
+			struct sort_impl<list<L0, L1>, list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11,
+			                                    T12, T13, T14, T15, T16, T17, Ts...>,
 			                 Comp>
-			    : sort_impl<list<L0, L1,
-			                     typename mini_sort<list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9,
-			                                             T10, T11, T12, T13, T14, T15, T16, T17>,
-			                                        Comp>::type>,
-			                list<Ts...>, Comp> {};
+			        : sort_impl<list<L0, L1, typename mini_sort<
+			                                         list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9,
+			                                              T10, T11, T12, T13, T14, T15, T16, T17>,
+			                                         Comp>::type>,
+			                    list<Ts...>, Comp> {};
 
 			template <class L0, class L1, class L2, class T0, class T1, class T2, class T3,
 			          class T4, class T5, class T6, class T7, class T8, class T9, class T10,
 			          class T11, class T12, class T13, class T14, class T15, class T16, class T17,
 			          class... Ts, template <typename...> class Comp>
-			struct sort_impl<list<L0, L1, L2>,
-			                 list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
-			                      T15, T16, T17, Ts...>,
+			struct sort_impl<list<L0, L1, L2>, list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
+			                                        T11, T12, T13, T14, T15, T16, T17, Ts...>,
 			                 Comp>
-			    : sort_impl<list<merge<L0, L1, Comp>,
-			                     merge<typename mini_sort<
-			                                   list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
-			                                        T11, T12, T13, T14, T15, T16, T17>,
-			                                   Comp>::type,
-			                           L2, Comp>>,
-			                list<Ts...>, Comp> {};
+			        : sort_impl<list<merge<L0, L1, Comp>,
+			                         merge<typename mini_sort<
+			                                       list<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10,
+			                                            T11, T12, T13, T14, T15, T16, T17>,
+			                                       Comp>::type,
+			                               L2, Comp>>,
+			                    list<Ts...>, Comp> {};
 
 			template <class T, class... Ts, template <typename...> class Comp>
 			struct sort_impl<list<>, list<T, Ts...>, Comp> {

--- a/src/kvasir/mpl/algorithm/split_if.hpp
+++ b/src/kvasir/mpl/algorithm/split_if.hpp
@@ -4,12 +4,13 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
-#include <type_traits>
-
 #include "../algorithm/fold_right.hpp"
 #include "../functional/call.hpp"
+#include "../functional/flow.hpp"
+#include "../sequence/at.hpp"
 #include "../sequence/push_front.hpp"
 #include "../types/list.hpp"
+#include "../utility/conditional.hpp"
 
 namespace kvasir {
 	namespace mpl {
@@ -21,28 +22,17 @@ namespace kvasir {
 				using type = list<list<U, Ts...>, Ls...>;
 			};
 
-			template <typename T>
-			struct split_next;
-			template <typename... Ls>
-			struct split_next<list<Ls...>> {
-				using type = list<list<>, Ls...>;
-			};
-
-			template <template <typename...> class F>
-			struct split_if_pred {
-				template <typename T, typename U>
-				using f = typename std::conditional<F<U>::value, split_next<T>,
-				                                    split_push<T, U>>::type::type;
-			};
+			template <typename F>
+			using split_if_pred = if_<at1<F>, at0<unpack<push_front<list<>>>>, cfl<split_push>>;
 		} // namespace detail
 		/// \brief splits a lits into multiple lists at every point for which the provided predicate
 		/// holds
 		template <typename F = identity, typename C = listify>
 		struct split_if {
 			template <typename... Ts>
-			using f = typename dcall<fold_right<detail::split_if_pred<F::template f>,
-			                                    push_front<unpack<C>, cfe<call>>>,
-			                         sizeof...(Ts)>::template f<list<list<>>, Ts...>;
+			using f = typename dcall<
+			        fold_right<detail::split_if_pred<F>, push_front<unpack<C>, cfe<call>>>,
+			        sizeof...(Ts)>::template f<list<list<>>, Ts...>;
 		};
 		namespace eager {
 			template <typename List, template <typename...> class F = identity>

--- a/src/kvasir/mpl/algorithm/transform.hpp
+++ b/src/kvasir/mpl/algorithm/transform.hpp
@@ -13,7 +13,7 @@ namespace kvasir {
 	namespace mpl {
 		/// \brief executes the continuation `F` on every element in the input pack passing the
 		/// results to the continuation `C`
-		template <typename F=identity, typename C = listify>
+		template <typename F = identity, typename C = listify>
 		struct transform {
 			template <typename... Ts>
 			using f = typename dcall<C, sizeof...(Ts)>::template f<typename F::template f<Ts>...>;

--- a/src/kvasir/mpl/sequence/at.hpp
+++ b/src/kvasir/mpl/sequence/at.hpp
@@ -15,34 +15,34 @@ namespace kvasir {
 		using at = drop<N, front<C>>;
 
 		template <typename C = identity>
-		using at0 = drop<uint_<0>, front<C>>;
+		using at0            = drop<uint_<0>, front<C>>;
 
 		template <typename C = identity>
-		using at1 = drop<uint_<1>, front<C>>;
+		using at1            = drop<uint_<1>, front<C>>;
 
 		template <typename C = identity>
-		using at2 = drop<uint_<2>, front<C>>;
+		using at2            = drop<uint_<2>, front<C>>;
 
 		template <typename C = identity>
-		using at3 = drop<uint_<3>, front<C>>;
+		using at3            = drop<uint_<3>, front<C>>;
 
 		template <typename C = identity>
-		using at4 = drop<uint_<4>, front<C>>;
+		using at4            = drop<uint_<4>, front<C>>;
 
 		template <typename C = identity>
-		using at5 = drop<uint_<5>, front<C>>;
+		using at5            = drop<uint_<5>, front<C>>;
 
 		template <typename C = identity>
-		using at6 = drop<uint_<6>, front<C>>;
+		using at6            = drop<uint_<6>, front<C>>;
 
 		template <typename C = identity>
-		using at7 = drop<uint_<7>, front<C>>;
+		using at7            = drop<uint_<7>, front<C>>;
 
 		template <typename C = identity>
-		using at8 = drop<uint_<8>, front<C>>;
+		using at8            = drop<uint_<8>, front<C>>;
 
 		template <typename C = identity>
-		using at9 = drop<uint_<9>, front<C>>;
+		using at9            = drop<uint_<9>, front<C>>;
 
 		namespace eager {
 			/// get the n-th element of the list

--- a/src/kvasir/mpl/sequence/lookup.hpp
+++ b/src/kvasir/mpl/sequence/lookup.hpp
@@ -177,7 +177,7 @@ namespace kvasir {
 				          typename T9 = void, typename T10 = void, typename T11 = void,
 				          typename T12 = void, typename T13 = void, typename T14 = void,
 				          typename T15 = void, typename...>
-				using f = detail::rlist<
+				using f                = detail::rlist<
 				        indexed<indexed<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13,
 				                        T14, T15>>,
 				        detail::rlist<

--- a/src/kvasir/mpl/types/traits.hpp
+++ b/src/kvasir/mpl/types/traits.hpp
@@ -3,6 +3,7 @@
 //    (See accompanying file LICENSE.md or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
+
 #include <type_traits>
 #include "bool.hpp"
 #include "../compatability/compatability.hpp"
@@ -356,16 +357,20 @@ namespace kvasir {
 			template <typename T>
 			using f = typename C::template f<bool_<std::is_destructible<T>::value>>;
 		};
+#if (__has_feature(is_trivially_destructible))
 		template <typename C = identity>
 		struct is_trivially_destructible {
 			template <typename T>
 			using f = typename C::template f<bool_<std::is_trivially_destructible<T>::value>>;
 		};
+#endif
+#if (__has_feature(is_nothrow_destructible))
 		template <typename C = identity>
 		struct is_nothrow_destructible {
 			template <typename T>
 			using f = typename C::template f<bool_<std::is_nothrow_destructible<T>::value>>;
 		};
+#endif
 		template <typename C = identity>
 		struct has_virtual_destructor {
 			template <typename T>

--- a/test/algorithm/all.hpp
+++ b/test/algorithm/all.hpp
@@ -20,13 +20,11 @@ namespace {
 			using namespace kvasir;
 			using namespace mpl;
 
-			call<all<cfe<comp>>, int, int, int, int>{} = true_{};
+			call<all<cfe<comp>>, int, int, int, int>{}  = true_{};
 			call<all<cfe<comp>>, int, int, bool, int>{} = false_{};
 
-			call<all<cfe<comp>>, int, int, int, int>{} = true_{};
+			call<all<cfe<comp>>, int, int, int, int>{}  = true_{};
 			call<all<cfe<comp>>, int, int, bool, int>{} = false_{};
-
 		}
 	};
-
 }

--- a/test/algorithm/any.hpp
+++ b/test/algorithm/any.hpp
@@ -16,8 +16,8 @@ namespace {
 		using comp = std::is_same<int, T>;
 
 		any_test() {
-			using namespace kvasir::mpl;	
-			call<any<cfe<comp>>, void, char, int, float>{} = true_{};
+			using namespace kvasir::mpl;
+			call<any<cfe<comp>>, void, char, int, float>{}  = true_{};
 			call<any<cfe<comp>>, void, char, bool, float>{} = false_{};
 			call<any<cfe<comp>>>{} = false_{};
 		}

--- a/test/algorithm/count_if.hpp
+++ b/test/algorithm/count_if.hpp
@@ -13,10 +13,10 @@ namespace {
 		using comp = std::is_same<int, t>;
 
 		count_if_test() {
-			using namespace kvasir::mpl;	
+			using namespace kvasir::mpl;
 			call<count_if<cfe<comp>>, void, char, bool, float>{} = uint_<0>{};
-			call<count_if<cfe<comp>>, void, char, int, float>{} = uint_<1>{};
-			call<count_if<cfe<comp>>, int, char, int, float>{} = uint_<2>{};
+			call<count_if<cfe<comp>>, void, char, int, float>{}  = uint_<1>{};
+			call<count_if<cfe<comp>>, int, char, int, float>{}   = uint_<2>{};
 			call<count_if<cfe<comp>>>{} = uint_<0>{};
 		}
 	};

--- a/test/algorithm/filter.hpp
+++ b/test/algorithm/filter.hpp
@@ -15,12 +15,14 @@ namespace {
 	using namespace kvasir::mpl;
 	template <typename T>
 	using less_than_5 = bool_<(T::value < 5)>;
-	struct filter_test{
-		filter_test(){
-			call<filter<cfe<less_than_5>>,int_<1>, int_<2>, int_<7>, int_<8>>{} = list<int_<1>, int_<2>>{};
-			call<filter<cfe<less_than_5>>,int_<9>, int_<2>, int_<7>, int_<8>>{} = list<int_<2>>{};
+	struct filter_test {
+		filter_test() {
+			call<filter<cfe<less_than_5>>, int_<1>, int_<2>, int_<7>, int_<8>>{} =
+			        list<int_<1>, int_<2>>{};
+			call<filter<cfe<less_than_5>>, int_<9>, int_<2>, int_<7>, int_<8>>{} = list<int_<2>>{};
 			call<filter<cfe<less_than_5>>>{} = list<>{};
-			call<filter<cfe<less_than_5>,cfe<list>>,int_<1>, int_<2>, int_<7>, int_<8>>{} = list<int_<1>, int_<2>>{};
+			call<filter<cfe<less_than_5>, cfe<list>>, int_<1>, int_<2>, int_<7>, int_<8>>{} =
+			        list<int_<1>, int_<2>>{};
 		}
 	};
 }

--- a/test/algorithm/find_if.hpp
+++ b/test/algorithm/find_if.hpp
@@ -8,12 +8,15 @@
 
 #include <kvasir/mpl/algorithm/find_if.hpp>
 #include <kvasir/mpl/functional/bind.hpp>
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/utility/is_same.hpp>
 
 namespace {
-	using namespace kvasir;
-	static_assert(std::is_same<mpl::eager::find_if<mpl::list<void, char, short, int>,
-	                                               mpl::same_as<char>::template f>,
-	                           mpl::list<char, short, int>>{},
-	              "");
+	struct find_if_test {
+		find_if_test() {
+			using namespace kvasir::mpl;
+
+			call<find_if<same_as<char>>, void, char, short, int>{} = list<char, short, int>{};
+		}
+	};
 }

--- a/test/algorithm/flatten.hpp
+++ b/test/algorithm/flatten.hpp
@@ -6,19 +6,23 @@
 
 #include <type_traits>
 
-#include <tuple>
 #include <kvasir/mpl/algorithm/flatten.hpp>
 #include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/types/list.hpp>
+
 namespace {
 	using namespace kvasir::mpl;
 	list<> t1 = call<flatten<>, list<list<list<>, list<>>, list<>>, list<>>{};
+	
+	template<typename...>
+	struct foo_list {
+	};
 	list<> t2 =
-	        call<flatten<cfe<std::tuple>>, std::tuple<std::tuple<>, std::tuple<>>, std::tuple<>>{};
-	std::tuple<> t3 = call<flatten<cfe<std::tuple>, cfe<std::tuple>>,
-	                       std::tuple<std::tuple<>, std::tuple<>>, std::tuple<>>{};
+	        call<flatten<cfe<foo_list>>, foo_list<foo_list<>, foo_list<>>, foo_list<>>{};
+	foo_list<> t3 = call<flatten<cfe<foo_list>, cfe<foo_list>>,
+	                       foo_list<foo_list<>, foo_list<>>, foo_list<>>{};
 	list<int, bool> t4 = call<flatten<>, list<int, bool>>{};
-	std::tuple<int, bool> t5 =
-	        call<flatten<cfe<std::tuple>, cfe<std::tuple>>, std::tuple<int, bool>>{};
-	std::tuple<int, bool> t6 = call<flatten<cfe<list>, cfe<std::tuple>>, list<int, list<bool>>>{};
+	foo_list<int, bool> t5 =
+	        call<flatten<cfe<foo_list>, cfe<foo_list>>, foo_list<int, bool>>{};
+	foo_list<int, bool> t6 = call<flatten<cfe<list>, cfe<foo_list>>, list<int, list<bool>>>{};
 }

--- a/test/algorithm/fold_right.hpp
+++ b/test/algorithm/fold_right.hpp
@@ -13,8 +13,7 @@
 #include <kvasir/mpl/types/list.hpp>
 
 namespace {
-	namespace mpl = kvasir::mpl;
-	using mpl::uint_;
+	using namespace kvasir::mpl;
 
 	template <typename T1, typename T2>
 	using add = uint_<(T1::value + T2::value)>;
@@ -22,65 +21,43 @@ namespace {
 	template <typename T, typename U>
 	struct push;
 	template <typename... Ts, typename U>
-	struct push<mpl::list<Ts...>, U> {
-		using type = mpl::list<U, Ts...>;
+	struct push<list<Ts...>, U> {
+		using type = list<U, Ts...>;
 	};
-
-	static_assert(
-	        std::is_same<mpl::eager::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>,
-	                                            uint_<0>, add>,
-	                     uint_<10>>::value,
-	        "");
-
-	static_assert(std::is_same<mpl::eager::fold_right<mpl::list<uint_<1>, uint_<2>>, mpl::list<>,
-	                                                  mpl::cfl<push>::template f>,
-	                           mpl::list<uint_<1>, uint_<2>>>::value,
-	              "");
-	static_assert(std::is_same<mpl::eager::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>>,
-	                                                  mpl::list<>, mpl::cfl<push>::template f>,
-	                           mpl::list<uint_<1>, uint_<2>, uint_<3>>>::value,
-	              "");
-	static_assert(
-	        std::is_same<mpl::eager::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>,
-	                                            mpl::list<>, mpl::cfl<push>::template f>,
-	                     mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>>::value,
-	        "");
-	static_assert(std::is_same<mpl::eager::fold_right<
-	                                   mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>>,
-	                                   mpl::list<>, mpl::cfl<push>::template f>,
-	                           mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>>>::value,
-	              "");
-	static_assert(
-	        std::is_same<
-	                mpl::eager::fold_right<
-	                        mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>>,
-	                        mpl::list<>, mpl::cfl<push>::template f>,
-	                mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>>>::value,
-	        "");
-	static_assert(
-	        std::is_same<mpl::eager::fold_right<mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>,
-	                                                      uint_<5>, uint_<6>, uint_<7>>,
-	                                            mpl::list<>, mpl::cfl<push>::template f>,
-	                     mpl::list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>,
-	                               uint_<7>>>::value,
-	        "");
 
 	template <typename C, typename T>
 	struct fold_right_foo {
 		template <typename... Ts>
-		using f = mpl::call<C, Ts..., T>;
+		using f = call<C, Ts..., T>;
 	};
 
-	static_assert(std::is_same<mpl::call<mpl::call<mpl::fold_right<mpl::cfe<fold_right_foo>>,
-	                                               mpl::listify, char, short, int>,
-	                                     void>,
-	                           mpl::list<void, char, short, int>>::value,
-	              "");
-
-	template<typename T>
+	template <typename T>
 	struct fold_right_cont_test {
 		template <typename... Ts>
-		using f = typename mpl::dcall<mpl::fold_right<mpl::cfe<add>>,
-		                         sizeof...(Ts)>::template f<uint_<1>, Ts...>;
+		using f = typename dcall<fold_right<cfe<add>>, sizeof...(Ts)>::template f<uint_<1>, Ts...>;
+	};
+
+	struct fold_right_test {
+
+		fold_right_test() {
+			eager::fold_right<list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>, uint_<0>, add>{} =
+			        uint_<10>{};
+
+			call<fold_right<cfl<push>>, list<>, uint_<1>, uint_<2>>{} = list<uint_<1>, uint_<2>>{};
+			call<fold_right<cfl<push>>, list<>, uint_<1>, uint_<2>, uint_<3>>{} =
+			        list<uint_<1>, uint_<2>, uint_<3>>{};
+			call<fold_right<cfl<push>>, list<>, uint_<1>, uint_<2>, uint_<3>, uint_<4>>{} =
+			        list<uint_<1>, uint_<2>, uint_<3>, uint_<4>>{};
+			call<fold_right<cfl<push>>, list<>, uint_<1>, uint_<2>, uint_<3>, uint_<4>,
+			     uint_<5>>{} = list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>>{};
+			call<fold_right<cfl<push>>, list<>, uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>,
+			     uint_<6>>{} = list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>>{};
+			call<fold_right<cfl<push>>, list<>, uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>,
+			     uint_<6>, uint_<7>>{} =
+			        list<uint_<1>, uint_<2>, uint_<3>, uint_<4>, uint_<5>, uint_<6>, uint_<7>>{};
+
+			call<call<fold_right<cfe<fold_right_foo>>, listify, char, short, int>, void>{} =
+			        list<void, char, short, int>{};
+		}
 	};
 }

--- a/test/algorithm/group.hpp
+++ b/test/algorithm/group.hpp
@@ -11,15 +11,15 @@ namespace {
 	struct group_test {
 		group_test() {
 			using namespace kvasir::mpl;
-			call<group<>>{}    = list<>{};
-			call<group<>,int>{} = list<list<int>>{};
-			call<group<>,int, double>{} = list<list<int>, list<double>>{};
-			call<group<>,int, double, float>{} = list<list<int>, list<double>, list<float>>{};
-			call<group<>,int, int, double, double, double, int, int, int, float>{} =
+			call<group<>>{} = list<>{};
+			call<group<>, int>{} = list<list<int>>{};
+			call<group<>, int, double>{} = list<list<int>, list<double>>{};
+			call<group<>, int, double, float>{} = list<list<int>, list<double>, list<float>>{};
+			call<group<>, int, int, double, double, double, int, int, int, float>{} =
 			        list<list<int, int>, list<double, double, double>, list<int, int, int>,
 			             list<float>>{};
-			using seq           = call<make_int_sequence<>,uint_<5>>;
-			call<unpack<group<>>,seq>{} = call<unpack<transform<cfe<list>>>, seq>{};
+			using seq = call<make_int_sequence<>, uint_<5>>;
+			call<unpack<group<>>, seq>{} = call<unpack<transform<cfe<list>>>, seq>{};
 		}
 	};
 }

--- a/test/algorithm/product.hpp
+++ b/test/algorithm/product.hpp
@@ -11,7 +11,7 @@
 #include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/types/list.hpp>
 
-namespace {
+namespace product_test {
 	namespace mpl = kvasir::mpl;
 
 	template <typename...>

--- a/test/algorithm/remove_if.hpp
+++ b/test/algorithm/remove_if.hpp
@@ -14,19 +14,18 @@ namespace remove_if_test {
 	using less_than_5 = bool_<(T::value < 5)>;
 
 	struct less_than_5_c {
-		template<typename T>
+		template <typename T>
 		using f = less_than_5<T>;
 	};
 
 	static_assert(
-		std::is_same<eager::remove_if<list<int_<1>, int_<2>, int_<7>, int_<8>>, less_than_5>,
-		list<int_<7>, int_<8>>>::value,
-		"");
+	        std::is_same<eager::remove_if<list<int_<1>, int_<2>, int_<7>, int_<8>>, less_than_5>,
+	                     list<int_<7>, int_<8>>>::value,
+	        "");
 
-	template<typename...Ts>
+	template <typename... Ts>
 	using test = call<remove_if<less_than_5_c>, Ts...>;
 	static_assert(
-		std::is_same<test<int_<1>, int_<2>, int_<7>, int_<8>>,
-		list<int_<7>, int_<8>>>::value,
-		"");
+	        std::is_same<test<int_<1>, int_<2>, int_<7>, int_<8>>, list<int_<7>, int_<8>>>::value,
+	        "");
 }

--- a/test/algorithm/stable_sort.hpp
+++ b/test/algorithm/stable_sort.hpp
@@ -11,7 +11,7 @@
 #include <kvasir/mpl/types/int.hpp>
 #include <kvasir/mpl/types/list.hpp>
 
-namespace {
+namespace stable_sort_test {
 	namespace mpl = kvasir::mpl;
 
 	template <typename A, typename B>

--- a/test/functional/flow.hpp
+++ b/test/functional/flow.hpp
@@ -2,5 +2,5 @@
 namespace {
 	using namespace kvasir;
 	using namespace mpl;
-	static_assert(call<if_<same_as<void>,always<false_>,always<true_>>,int>::value,"");
+	static_assert(call<if_<same_as<void>, always<false_>, always<true_>>, int>::value, "");
 }

--- a/test/functions/bitwise/bitwise_and.hpp
+++ b/test/functions/bitwise/bitwise_and.hpp
@@ -4,9 +4,18 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/bitwise/bitwise_and.hpp>
+#include <kvasir/mpl/types/int.hpp>
 #include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
 
-static_assert(std::is_same<kvasir::mpl::eager::bitwise_and<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::integral_constant<unsigned, 0>>::value, "");
-static_assert(std::is_same<kvasir::mpl::bitwise_and<>::template f<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::integral_constant<unsigned, 0>>::value, "");
+namespace {
+	struct bitwise_and_test {
+		bitwise_and_test() {
+			using namespace kvasir::mpl;
+
+			eager::bitwise_and<uint_<0>, uint_<1>>{} = integral_constant<unsigned long long, 0>{};
+			call<bitwise_and<>, uint_<0>, uint_<1>>{} = integral_constant<unsigned long long, 0>{};
+		}
+	};
+}

--- a/test/functions/bitwise/bitwise_complement.hpp
+++ b/test/functions/bitwise/bitwise_complement.hpp
@@ -4,10 +4,20 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/bitwise/bitwise_complement.hpp>
+#include <kvasir/mpl/types/int.hpp>
 #include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
 
+namespace {
+	struct bitwise_complement_test {
+		bitwise_complement_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::bitwise_complement<kvasir::mpl::integral_constant<unsigned, 0>>, kvasir::mpl::integral_constant<unsigned, (~0U)>>::value, "");
-static_assert(std::is_same<kvasir::mpl::bitwise_complement<>::template f<kvasir::mpl::integral_constant<unsigned, 0>>, kvasir::mpl::integral_constant<unsigned, (~0U)>>::value, "");
+			eager::bitwise_complement<uint_<0>>{} =
+			        integral_constant<unsigned long long, (~0ull)>{};
+			call<bitwise_complement<>, uint_<0>>{} =
+			        integral_constant<unsigned long long, (~0ull)>{};
+		}
+	};
+}

--- a/test/functions/bitwise/bitwise_or.hpp
+++ b/test/functions/bitwise/bitwise_or.hpp
@@ -4,10 +4,18 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/bitwise/bitwise_or.hpp>
+#include <kvasir/mpl/types/int.hpp>
 #include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
 
+namespace {
+	struct bitwise_or_test {
+		bitwise_or_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::bitwise_or<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::integral_constant<unsigned, 1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::bitwise_or<>::template f<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::integral_constant<unsigned, 1>>::value, "");
+			eager::bitwise_or<uint_<0>, uint_<1>>{} = integral_constant<unsigned long long, 1>{};
+			call<bitwise_or<>, uint_<0>, uint_<1>>{} = integral_constant<unsigned long long, 1>{};
+		}
+	};
+}

--- a/test/functions/bitwise/bitwise_xor.hpp
+++ b/test/functions/bitwise/bitwise_xor.hpp
@@ -4,9 +4,22 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <type_traits>
 #include <kvasir/mpl/functions/bitwise/bitwise_xor.hpp>
 #include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
 
-static_assert(std::is_same<kvasir::mpl::eager::bitwise_xor<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::integral_constant<unsigned, 1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::bitwise_xor<>::template f<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::integral_constant<unsigned, 1>>::value, "");
+#include <kvasir/mpl/functional/call.hpp>
+#include <kvasir/mpl/functions/bitwise/bitwise_xor.hpp>
+#include <kvasir/mpl/types/int.hpp>
+#include <kvasir/mpl/types/integral_constant.hpp>
+
+namespace {
+	struct bitwise_xor_test {
+		bitwise_xor_test() {
+			using namespace kvasir::mpl;
+
+			eager::bitwise_xor<uint_<0>, uint_<1>>{} = integral_constant<unsigned long long, 1>{};
+			call<bitwise_xor<>, uint_<0>, uint_<1>>{} = integral_constant<unsigned long long, 1>{};
+		}
+	};
+}

--- a/test/functions/comparison/equal.hpp
+++ b/test/functions/comparison/equal.hpp
@@ -4,10 +4,18 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/comparison/equal.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/bool.hpp>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct equal_test {
+		equal_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::equal<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::bool_<false>>::value, "");
-static_assert(std::is_same<kvasir::mpl::equal<>::template f<kvasir::mpl::integral_constant<unsigned, 0>, kvasir::mpl::integral_constant<unsigned, 1>>, kvasir::mpl::bool_<false>>::value, "");
+			eager::equal<uint_<0>, uint_<1>>{} = bool_<false>{};
+			call<equal<>, uint_<0>, uint_<1>>{} = bool_<false>{};
+		}
+	};
+}

--- a/test/functions/comparison/greater_than.hpp
+++ b/test/functions/comparison/greater_than.hpp
@@ -4,10 +4,17 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/comparison/greater_than.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct greater_than_test {
+		greater_than_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::greater_than<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<0>>::value, "");
-static_assert(std::is_same<kvasir::mpl::greater_than<>::template f<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<0>>::value, "");
+			eager::greater_than<int_<0>, int_<1>>{} = bool_<false>{};
+			call<greater_than<>, int_<0>, int_<1>>{} = bool_<false>{};
+		}
+	};
+}

--- a/test/functions/comparison/greater_than_or_equal.hpp
+++ b/test/functions/comparison/greater_than_or_equal.hpp
@@ -4,10 +4,17 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/comparison/greater_than_or_equal.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct greater_than_or_equal_test {
+		greater_than_or_equal_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::greater_than_or_equal<kvasir::mpl::integral_constant<int, 1>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::greater_than_or_equal<>::template f<kvasir::mpl::integral_constant<int, 1>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
+			eager::greater_than_or_equal<int_<1>, int_<1>>{} = bool_<true>{};
+			call<greater_than_or_equal<>, int_<1>, int_<1>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/functions/comparison/less_than.hpp
+++ b/test/functions/comparison/less_than.hpp
@@ -4,10 +4,17 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/comparison/less_than.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct less_than_test {
+		less_than_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::less_than<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::less_than<>::template f<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
+			eager::less_than<int_<0>, int_<1>>{} = bool_<true>{};
+			call<less_than<>, int_<0>, int_<1>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/functions/comparison/less_than_or_equal.hpp
+++ b/test/functions/comparison/less_than_or_equal.hpp
@@ -4,10 +4,17 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/comparison/less_than_or_equal.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct less_than_or_equal_test {
+		less_than_or_equal_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::less_than_or_equal<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::less_than_or_equal<>::template f<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
+			eager::less_than_or_equal<int_<0>, int_<1>>{} = bool_<true>{};
+			call<less_than_or_equal<>, int_<0>, int_<1>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/functions/comparison/not_equal.hpp
+++ b/test/functions/comparison/not_equal.hpp
@@ -4,10 +4,17 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/comparison/not_equal.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct not_equal_test {
+		not_equal_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::not_equal<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::not_equal<>::template f<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
+			eager::not_equal<uint_<0>, uint_<1>>{} = bool_<true>{};
+			call<not_equal<>, uint_<0>, uint_<1>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/functions/logical/logical_and.hpp
+++ b/test/functions/logical/logical_and.hpp
@@ -4,10 +4,18 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/logical/logical_and.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/bool.hpp>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct logical_and_test {
+		logical_and_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::logical_and<kvasir::mpl::integral_constant<int, 2>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::logical_and<>::template f<kvasir::mpl::integral_constant<int, 2>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
+			eager::logical_and<uint_<2>, uint_<1>>{} = bool_<true>{};
+			call<logical_and<>, uint_<2>, uint_<1>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/functions/logical/logical_not.hpp
+++ b/test/functions/logical/logical_not.hpp
@@ -4,10 +4,19 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
-#include <kvasir/mpl/functions/logical/logical_not.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
 #include <type_traits>
+#include <kvasir/mpl/functional/call.hpp>
+#include <kvasir/mpl/functions/logical/logical_not.hpp>
+#include <kvasir/mpl/types/bool.hpp>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct logical_not_test {
+		logical_not_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::logical_not<kvasir::mpl::integral_constant<int, 0>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::logical_not<>::template f<kvasir::mpl::integral_constant<int, 0>>, kvasir::mpl::bool_<1>>::value, "");
+			eager::logical_not<uint_<0>>{} = bool_<true>{};
+			call<logical_not<>, uint_<0>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/functions/logical/logical_or.hpp
+++ b/test/functions/logical/logical_or.hpp
@@ -4,12 +4,18 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/functions/logical/logical_or.hpp>
-#include <kvasir/mpl/types/integral_constant.hpp>
-#include <type_traits>
+#include <kvasir/mpl/types/bool.hpp>
+#include <kvasir/mpl/types/int.hpp>
 
+namespace {
+	struct logical_or_test {
+		logical_or_test() {
+			using namespace kvasir::mpl;
 
-static_assert(std::is_same<kvasir::mpl::eager::logical_or<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-static_assert(std::is_same<kvasir::mpl::logical_or<>::template f<kvasir::mpl::integral_constant<int, 0>, kvasir::mpl::integral_constant<int, 1>>, kvasir::mpl::bool_<1>>::value, "");
-
-
+			eager::logical_or<uint_<0>, uint_<1>>{} = bool_<true>{};
+			call<logical_or<>, uint_<0>, uint_<1>>{} = bool_<true>{};
+		}
+	};
+}

--- a/test/sequence/at.hpp
+++ b/test/sequence/at.hpp
@@ -14,9 +14,28 @@ namespace {
 	namespace mpl = kvasir::mpl;
 
 	static_assert(std::is_same<mpl::eager::at<mpl::list<void, char, short>, 1>, char>::value, "");
-	static_assert(std::is_same<mpl::eager::at<mpl::list<int, int, int, int, int, int, int, void, char, short>, 7>, void>::value, "");
-	static_assert(std::is_same<mpl::eager::at<mpl::list<int, int, int, int, int, int, int, void, char, short>, 8>, char>::value, "");
-	static_assert(std::is_same<mpl::eager::at<mpl::list<int, int, int, int, int, int, int, void, char, short>, 9>, short>::value, "");
-	static_assert(std::is_same<mpl::eager::at<mpl::list<
-		int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int,	void, char, short>, 17>, char>::value, "");
+	static_assert(
+	        std::is_same<
+	                mpl::eager::at<mpl::list<int, int, int, int, int, int, int, void, char, short>,
+	                               7>,
+	                void>::value,
+	        "");
+	static_assert(
+	        std::is_same<
+	                mpl::eager::at<mpl::list<int, int, int, int, int, int, int, void, char, short>,
+	                               8>,
+	                char>::value,
+	        "");
+	static_assert(
+	        std::is_same<
+	                mpl::eager::at<mpl::list<int, int, int, int, int, int, int, void, char, short>,
+	                               9>,
+	                short>::value,
+	        "");
+	static_assert(
+	        std::is_same<mpl::eager::at<mpl::list<int, int, int, int, int, int, int, int, int, int,
+	                                              int, int, int, int, int, int, void, char, short>,
+	                                    17>,
+	                     char>::value,
+	        "");
 }

--- a/test/sequence/size.hpp
+++ b/test/sequence/size.hpp
@@ -4,15 +4,21 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/sequence/size.hpp>
 
-namespace size_test {
-	using namespace kvasir::mpl;
-	static_assert(size<>::template f<>::value == 0, "size test failed");
-	static_assert(size<>::template f<int>::value == 1, "size test failed");
-	static_assert(size<>::template f<int, int>::value == 2, "size test failed");
-	static_assert(size<>::template f<int, int, int>::value == 3, "size test failed");
-	static_assert(size<>::template f<int, int, int, int>::value == 4, "size test failed");
-	static_assert(size<>::template f<int, int, int, int, int>::value == 5, "size test failed");
-	static_assert(size<>::template f<int, int, int, int, int, int>::value == 6, "size test failed");
+namespace {
+	struct size_test {
+		size_test() {
+			using namespace kvasir::mpl;
+
+			call<size<>>{} = uint_<0>{};
+			call<size<>, int>{} = uint_<1>{};
+			call<size<>, int, int>{} = uint_<2>{};
+			call<size<>, int, int, int>{} = uint_<3>{};
+			call<size<>, int, int, int, int>{} = uint_<4>{};
+			call<size<>, int, int, int, int, int>{} = uint_<5>{};
+			call<size<>, int, int, int, int, int, int>{} = uint_<6>{};
+		}
+	};
 }

--- a/test/utility/always.hpp
+++ b/test/utility/always.hpp
@@ -4,14 +4,18 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
-#include <type_traits>
-
+#include <kvasir/mpl/functional/call.hpp>
+#include <kvasir/mpl/types/bool.hpp>
 #include <kvasir/mpl/utility/always.hpp>
 
 namespace {
 	namespace mpl = kvasir::mpl;
 
-	static_assert(std::is_same<mpl::always<int>::template f<void>, int>::value, "");
+	struct always_test {
+		always_test() {
+			mpl::call<mpl::always<mpl::bool_<false>>, void>{} = mpl::bool_<false>{};
+		}
+	};
 
 	template <typename T>
 	struct foo {

--- a/test/utility/conditional.hpp
+++ b/test/utility/conditional.hpp
@@ -4,11 +4,17 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 #pragma once
 
-#include <kvasir/mpl/utility/conditional.hpp>
+#include <kvasir/mpl/functional/call.hpp>
 #include <kvasir/mpl/types/bool.hpp>
+#include <kvasir/mpl/utility/conditional.hpp>
 
-namespace conditional_test {
-	using namespace kvasir::mpl;
-	static_assert(conditional<true>::template f <bool_< true >, bool_<false >> ::value, "conditional test failed");
-	static_assert(conditional<false>::template f <bool_< true >, bool_<false >> ::value == false, "conditional test failed");
+namespace {
+	struct conditional_test {
+		conditional_test() {
+			using namespace kvasir::mpl;
+
+			call<conditional<true>, bool_<true>, bool_<false>>{}  = bool_<true>{};
+			call<conditional<false>, bool_<true>, bool_<false>>{} = bool_<false>{};
+		}
+	};
 }


### PR DESCRIPTION
This should fix the travis builds for gcc version 4.7 and 4.8, replacing most tests with the new testing style to remove any template keywords, as they are not allowed in untemplated contexts in gcc 4.8.
Be wary that in gcc <= 4.8, there is an apparent aversion to using singular template parameters after parameter packs, supposedly due to some bug.