### PR TITLE
replaced 'std::is_pod' by 'std::is_standard_layout && std::is_trivial' to silence warnings

### DIFF
--- a/src/kvasir/mpl/types/traits.hpp
+++ b/src/kvasir/mpl/types/traits.hpp
@@ -192,7 +192,7 @@ namespace kvasir {
 		template <typename C = identity>
 		struct is_pod {
 			template <typename T>
-			using f = typename C::template f<bool_<std::is_pod<T>::value>>;
+			using f = typename C::template f<bool_<std::is_standard_layout<T>::value && std::is_trivial<T>::value>>;
 		};
 		template <typename C = identity>
 		struct is_literal_type {


### PR DESCRIPTION
'std::is_pod' is deprecated in C++20.
This change will silence g++ warnings when using -std=c++2a.